### PR TITLE
Added a check to make sure a node was not an abstract base class before generating its widget

### DIFF
--- a/scripts/regenerate_widgets.py
+++ b/scripts/regenerate_widgets.py
@@ -272,7 +272,7 @@ def generate_widget_code(resource_path, widget_path, modules):
             module = importlib.import_module('neuropype.nodes.%s' % modname)
             for key, value in inspect.getmembers(module):
                 if (isinstance(value, type) and issubclass(value, Node)
-                        and value != Node):
+                        and (not inspect.isabstract(value)) and value != Node):
                     nodes.append(value)
         except ImportError as e:
             print("  could not import module neuropype.nodes.%s; ignoring "


### PR DESCRIPTION
This makes it possible to create abstract base nodes in cpe that contain functionality shared across several different similar nodes, and the abstract base nodes will not be used to make widgets in vpe.
